### PR TITLE
`ThreedeeModel` and `QtThreeDeeWidgetBase`

### DIFF
--- a/examples/rendering_plane.py
+++ b/examples/rendering_plane.py
@@ -17,7 +17,7 @@ volume_layer = viewer.add_image(
 # plane should be in 'additive' blending mode or depth looks all wrong
 plane_parameters = {
     'position': (32, 32, 32),
-    'normal': (1, 0, 0),
+    'normal': (1, 1, 1),
     'thickness': 10,
     'enabled': True
 }

--- a/examples/rendering_plane_widget.py
+++ b/examples/rendering_plane_widget.py
@@ -1,0 +1,38 @@
+import napari
+from skimage import data
+
+from napari_threedee.manipulators import RenderPlaneManipulator
+from napari_threedee.manipulators.qt_render_plane_manipulator import QtRenderPlaneManipulatorWidget
+
+viewer = napari.Viewer(ndisplay=3)
+
+# add a volume
+blobs = data.binary_blobs(
+    length=64, volume_fraction=0.1, n_dim=3
+).astype(float)
+volume_layer = viewer.add_image(
+    blobs, rendering='mip', name='volume', blending='additive', opacity=0.25
+)
+
+# add the same volume and render as plane
+# plane should be in 'additive' blending mode or depth looks all wrong
+plane_parameters = {
+    'position': (32, 32, 32),
+    'normal': (1, 0, 0),
+    'thickness': 10,
+    'enabled': True
+}
+
+plane_layer = viewer.add_image(
+    blobs,
+    rendering='average',
+    name='plane',
+    colormap='bop orange',
+    blending='additive',
+    opacity=0.5,
+    experimental_slicing_plane=plane_parameters
+)
+
+widget = QtRenderPlaneManipulatorWidget(viewer)
+viewer.window.add_dock_widget(widget)
+napari.run()

--- a/src/napari_threedee/_dock_widget.py
+++ b/src/napari_threedee/_dock_widget.py
@@ -14,7 +14,6 @@ from functools import partial
 
 from .mouse_callbacks import add_point_on_plane, shift_plane_along_normal
 
-
 class QtPlaneControls(QWidget):
     def __init__(self, viewer: napari.viewer.Viewer):
         super().__init__()
@@ -51,4 +50,4 @@ def example_magic_widget(img_layer: "napari.layers.Image"):
 @napari_hook_implementation
 def napari_experimental_provide_dock_widget():
     # you can return either a single widget, or a sequence of widgets
-    return QtPlaneControls
+    return QtPlaneControls,

--- a/src/napari_threedee/annotators/plane_point_annotator.py
+++ b/src/napari_threedee/annotators/plane_point_annotator.py
@@ -1,37 +1,25 @@
-from functools import partial
-from typing import Optional, TYPE_CHECKING
-
-from ..utils.napari_utils import add_mouse_callback_safe, remove_mouse_callback_safe
-from ..mouse_callbacks import add_point_on_plane
+from typing import Optional
 
 import napari
 from napari.layers import Image, Points
 
+from ..base import ThreeDeeModel
+from ..mouse_callbacks import add_point_on_plane
+from ..utils.napari_utils import add_mouse_callback_safe, remove_mouse_callback_safe
 
-class PlanePointAnnotator:
+
+class PlanePointAnnotator(ThreeDeeModel):
     def __init__(
             self,
             viewer: napari.Viewer,
             image_layer: Optional[Image] = None,
             points_layer: Optional[Points] = None,
-            annotating: bool = False
+            enabled: bool = False
     ):
         self.viewer = viewer
         self.image_layer = image_layer
         self.points_layer = points_layer
-        self.annotating = annotating
-
-    @property
-    def annotating(self) -> bool:
-        return self._annotating
-
-    @annotating.setter
-    def annotating(self, value: bool):
-        if value is True:
-            self.bind_callbacks()
-        else:
-            self.unbind_callbacks()
-        self._annotating = value
+        self.enabled = enabled
 
     def _mouse_callback(self, viewer, event):
         if (self.image_layer is None) and (self.points_layer is None):
@@ -43,12 +31,20 @@ class PlanePointAnnotator:
             plane_layer=self.image_layer
         )
 
-    def bind_callbacks(self):
+    def set_layers(
+            self,
+            image_layer: napari.layers.Image,
+            points_layer: napari.layers.Points
+    ):
+        self.image_layer = image_layer
+        self.points_layer = points_layer
+
+    def enable(self):
         add_mouse_callback_safe(
             self.viewer.mouse_drag_callbacks, self._mouse_callback
         )
 
-    def unbind_callbacks(self):
+    def disable(self):
         remove_mouse_callback_safe(
             self.viewer.mouse_drag_callbacks, self._mouse_callback
         )

--- a/src/napari_threedee/annotators/plane_point_annotator.py
+++ b/src/napari_threedee/annotators/plane_point_annotator.py
@@ -39,12 +39,12 @@ class PlanePointAnnotator(ThreeDeeModel):
         self.image_layer = image_layer
         self.points_layer = points_layer
 
-    def enable(self):
+    def _on_enable(self):
         add_mouse_callback_safe(
             self.viewer.mouse_drag_callbacks, self._mouse_callback
         )
 
-    def disable(self):
+    def _on_disable(self):
         remove_mouse_callback_safe(
             self.viewer.mouse_drag_callbacks, self._mouse_callback
         )

--- a/src/napari_threedee/annotators/qt_plane_point_annotator.py
+++ b/src/napari_threedee/annotators/qt_plane_point_annotator.py
@@ -1,49 +1,10 @@
-from magicgui import magicgui
-from qtpy.QtWidgets import QPushButton, QWidget, QVBoxLayout
-from napari.layers import Image, Points
-from typing import List
 import napari
+
+from ..base import QtThreeDeeWidgetBase
+
 from .plane_point_annotator import PlanePointAnnotator
 
 
-
-class PlanePointAnnotatorWidget(QWidget):
+class PlanePointAnnotatorWidget(QtThreeDeeWidgetBase):
     def __init__(self, viewer: napari.Viewer):
-        super().__init__()
-        self._viewer = viewer
-        self.annotator = PlanePointAnnotator(self._viewer)
-
-        self._layer_selection_widget = magicgui(
-            self.update_layers,
-            image_layer={'choices': self._get_image_layers},
-            points_layer={'choices': self._get_points_layers},
-            auto_call=True
-        )
-        self._annotating_button = QPushButton('start annotating', self)
-        self._annotating_button.setCheckable(True)
-        self._annotating_button.setChecked(False)
-        self._annotating_button.clicked.connect(self._on_annotating_clicked)
-
-        self.setLayout(QVBoxLayout())
-        self.layout().addWidget(self._layer_selection_widget.native)
-        self.layout().addWidget(self._annotating_button)
-
-        self._layer_selection_widget()  # call with auto-populated layers
-
-    def update_layers(self, image_layer: Image, points_layer: Points):
-        self.annotator.points_layer = points_layer
-        self.annotator.image_layer = image_layer
-
-    def _on_annotating_clicked(self, event):
-        if self._annotating_button.isChecked() is True:
-            self.annotator.annotating = True
-            self._annotating_button.setText('stop annotating')
-        else:
-            self.annotator.annotating = False
-            self._annotating_button.setText('start annotating')
-
-    def _get_image_layers(self, combo_widget) -> List[Image]:
-        return [layer for layer in self._viewer.layers if isinstance(layer, Image)]
-
-    def _get_points_layers(self, combo_widget) -> List[Points]:
-        return [layer for layer in self._viewer.layers if isinstance(layer, Points)]
+        super().__init__(model=PlanePointAnnotator, viewer=viewer)

--- a/src/napari_threedee/base.py
+++ b/src/napari_threedee/base.py
@@ -1,0 +1,26 @@
+from abc import ABC, abstractmethod
+
+class ThreeDeeGUI(ABC):
+    """Base class for GUI elements in napari-threedee."""
+
+    @abstractmethod
+    def layer_selection(self):
+        """This method should set the layers the class is currently acting on.
+
+        The signature of this method should be typed with napari layer types.
+        """
+        pass
+
+    @abstractmethod
+    def enable(self):
+        """This method should 'activate' the manipulator/annotator,
+        setting state and connecting callbacks.
+        """
+        pass
+
+    @abstractmethod
+    def disable(self):
+        """This method should deactivate the manipulator/annotator,
+        updating state and disconnecting callbacks.
+        """
+        pass

--- a/src/napari_threedee/base.py
+++ b/src/napari_threedee/base.py
@@ -1,26 +1,74 @@
-from abc import ABC, abstractmethod
+from abc import ABC, abstractmethod, abstractproperty
+from typing import Type, Dict
 
-class ThreeDeeGUI(ABC):
-    """Base class for GUI elements in napari-threedee."""
+import napari
+from napari.utils.events import Event
+from qtpy.QtWidgets import QWidget, QPushButton, QVBoxLayout
 
-    @abstractmethod
-    def layer_selection(self):
-        """This method should set the layers the class is currently acting on.
+from .utils.napari_utils import generate_populated_layer_selection_widget
 
-        The signature of this method should be typed with napari layer types.
-        """
-        pass
 
-    @abstractmethod
+class ThreeDeeModel(ABC):
+    @property
+    def enabled(self):
+        return self._enabled
+
+    @enabled.setter
+    def enabled(self, value: bool):
+        self.enable() if value is True else self.disable()
+        self._enabled = value
+
     def enable(self):
         """This method should 'activate' the manipulator/annotator,
         setting state and connecting callbacks.
         """
-        pass
+        raise NotImplementedError
 
-    @abstractmethod
     def disable(self):
         """This method should deactivate the manipulator/annotator,
         updating state and disconnecting callbacks.
         """
+        raise NotImplementedError
+
+    @abstractmethod
+    def set_layers(self, *args):
+        """This method should set layer attributes on the manipulator/annotator.
+        Arguments to this function should be typed as napari layers.
+        """
         pass
+
+
+class QtThreeDeeWidgetBase(QWidget):
+    """Base class for GUI elements in napari-threedee."""
+
+    def __init__(self, model: Type[ThreeDeeModel], viewer: napari.Viewer, flags=None, *args, **kwargs):
+        super().__init__(flags, *args, **kwargs)
+        self.model = model(viewer)
+        self.viewer = viewer
+
+        self._layer_selection_widget = generate_populated_layer_selection_widget(
+            func=self.model.set_layers, viewer=viewer
+        )
+        self._layer_selection_widget()
+        self.activate_button = QPushButton('activate')
+        self.activate_button.setCheckable(True)
+        self.activate_button.setChecked(False)
+
+        self.setLayout(QVBoxLayout())
+        self.layout().addWidget(self.layer_selection_widget)
+        self.layout().addWidget(self.activate_button)
+
+        self.activate_button.clicked.connect(self.on_activate_button_click)
+
+    @property
+    def layer_selection_widget(self) -> QWidget:
+        return self._layer_selection_widget.native
+
+    def on_activate_button_click(self, event: Event):
+        if self.activate_button.isChecked() is True:
+            self.model.enabled = True
+            self.activate_button.setText('deactivate')
+        else:
+            self.model.enabled = False
+            self.activate_button.setText('activate')
+

--- a/src/napari_threedee/base.py
+++ b/src/napari_threedee/base.py
@@ -63,6 +63,9 @@ class QtThreeDeeWidgetBase(QWidget):
             func=self.model.set_layers, viewer=viewer
         )
         self._layer_selection_widget()
+
+        # start in the disabled state
+        self.model.enabled = False
         self.activate_button = QPushButton('activate')
         self.activate_button.setCheckable(True)
         self.activate_button.setChecked(False)

--- a/src/napari_threedee/base.py
+++ b/src/napari_threedee/base.py
@@ -1,5 +1,5 @@
-from abc import ABC, abstractmethod, abstractproperty
-from typing import Type, Dict
+from abc import ABC, abstractmethod
+from typing import Type
 
 import napari
 from napari.utils.events import Event
@@ -9,26 +9,24 @@ from .utils.napari_utils import generate_populated_layer_selection_widget
 
 
 class ThreeDeeModel(ABC):
+    """Base class for manipulators and annotators.
+
+    To implement:
+        - the __init__() should take the viewer as the first argument and all
+        keyword arguments should have default values.
+        - implement the set_layers() method
+        - implement the _on_enable() callback
+        - implement the _on_disable() callback
+    """
+
     @property
     def enabled(self):
         return self._enabled
 
     @enabled.setter
     def enabled(self, value: bool):
-        self.enable() if value is True else self.disable()
+        self._on_enable() if value is True else self._on_disable()
         self._enabled = value
-
-    def enable(self):
-        """This method should 'activate' the manipulator/annotator,
-        setting state and connecting callbacks.
-        """
-        raise NotImplementedError
-
-    def disable(self):
-        """This method should deactivate the manipulator/annotator,
-        updating state and disconnecting callbacks.
-        """
-        raise NotImplementedError
 
     @abstractmethod
     def set_layers(self, *args):
@@ -37,11 +35,26 @@ class ThreeDeeModel(ABC):
         """
         pass
 
+    @abstractmethod
+    def _on_enable(self):
+        """This method should 'activate' the manipulator/annotator,
+        setting state and connecting callbacks.
+        """
+        pass
+
+    @abstractmethod
+    def _on_disable(self):
+        """This method should 'deactivate' the manipulator/annotator,
+        updating state and disconnecting callbacks.
+        """
+        pass
+
 
 class QtThreeDeeWidgetBase(QWidget):
     """Base class for GUI elements in napari-threedee."""
 
-    def __init__(self, model: Type[ThreeDeeModel], viewer: napari.Viewer, flags=None, *args, **kwargs):
+    def __init__(self, model: Type[ThreeDeeModel], viewer: napari.Viewer, flags=None, *args,
+                 **kwargs):
         super().__init__(flags, *args, **kwargs)
         self.model = model(viewer)
         self.viewer = viewer
@@ -71,4 +84,3 @@ class QtThreeDeeWidgetBase(QWidget):
         else:
             self.model.enabled = False
             self.activate_button.setText('activate')
-

--- a/src/napari_threedee/manipulators/base_manipulator.py
+++ b/src/napari_threedee/manipulators/base_manipulator.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Type
 
+import napari
 import numpy as np
 from napari.utils.geometry import project_points_onto_plane, rotation_matrix_from_vectors_3d
 from napari.utils.translations import trans
@@ -8,23 +9,26 @@ from napari.viewer import Viewer
 from vispy.scene import Mesh
 from vispy.visuals.transforms import MatrixTransform
 
-from .manipulator_utils import make_translator_meshes, select_rotator, color_lines, make_rotator_meshes
-from ..utils.selection_utils import select_line_segment, select_mesh_from_click
-from ..utils.napari_utils import get_vispy_node, get_napari_visual, add_mouse_callback_safe, remove_mouse_callback_safe
+from .manipulator_utils import make_translator_meshes, color_lines, make_rotator_meshes
+from ..base import ThreeDeeModel
+from ..utils.napari_utils import get_vispy_node, add_mouse_callback_safe, remove_mouse_callback_safe
+from ..utils.selection_utils import select_mesh_from_click
 
 
-class BaseManipulator(ABC):
+class BaseManipulator(ThreeDeeModel, ABC):
     """Base class for manipulators.
 
     To implement:
-        1. Define self._initial_translator_normals in the __init__. This a
-        (Nx3) numpy array containing the normal direction for each of the N
-        translators to be created defined in displayed data coordinates.
-        2. Define self._initial_rotator_normals in the __init__. This a
-        (Nx3) numpy array containing the normal direction for each of the N
-        rotators to be created defined in displayed data coordinates.
-        3. Call the super.__init__() last.
-        4. Implement the drag callback functions
+        - the __init__() should take the viewer as the first argument, the layer
+            as the second argument followed by any keyword arguments.
+            Keyword arguments should have default values.
+        - implement the self._initial_translation_vectors property.
+        - implement the self._initial_rotator_normals property.
+        - implement the _pre_drag() callback.
+        - implement the _while_dragging_translator() callback.
+        - implement the _while_dragging_rotator() callback.
+        - implement the _post_drag() callback.
+        - Call the super.__init__().
 
     Parameters
     ----------
@@ -48,7 +52,7 @@ class BaseManipulator(ABC):
     translation : np.ndarray
         (3, 1) array containing the coordinates to the translation of the manipulator.
     rot_mat : np.ndarray
-        (3, 3) array containing the rotation matrix applied to the manipluator.
+        (3, 3) array containing the rotation matrix applied to the manipulator.
     translator_length : float
         The length of the translator arms in data units.
     translator_width : float
@@ -74,11 +78,12 @@ class BaseManipulator(ABC):
     """
     _N_SEGMENTS_ROTATOR = 50
     _N_TUBE_POINTS = 15
+
     def __init__(
             self,
             viewer,
             layer=None,
-            visible: bool = True,
+            enabled: bool = True,
             order: int = 0,
             translator_length: float = 50,
             translator_width: float = 1,
@@ -138,16 +143,24 @@ class BaseManipulator(ABC):
 
         self._viewer.camera.events.zoom.connect(self._on_zoom_change)
 
-        self.visible = visible
+        self.enabled = enabled
         self._on_matrix_change()
         self._on_data_change()
 
+    @property
+    def _initial_translation_vectors(self):
+        """An (Nx3) numpy array containing the translation vector for each of the
+        N translators to be created.
+
+        Translation vectors are defined in displayed data coordinates.
+        """
+        return np.empty((0, 3))
 
     def _init_translators(self):
         translator_vertices, translator_indices, translator_colors, triangle_indices = make_translator_meshes(
             centroids=np.asarray([0, 0, 0]),
-            normals=self._initial_translator_normals,
-            colors=self._default_color[:len(self._initial_translator_normals)],
+            normals=self._initial_translation_vectors,
+            colors=self._default_color[:len(self._initial_translation_vectors)],
             translator_length=self.translator_length,
             tube_radius=self._translator_width,
             tube_points=self._N_TUBE_POINTS,
@@ -158,7 +171,16 @@ class BaseManipulator(ABC):
         self.translator_colors = translator_colors
         self.translator_triangle_indices = triangle_indices
 
-        self._translator_normals = self._initial_translator_normals.copy()
+        self._translator_normals = self._initial_translation_vectors.copy()
+
+    @property
+    def _initial_rotator_normals(self):
+        """An (Nx3) numpy array containing the normal direction for each of the
+        N rotators to be created.
+
+        Normal directions are defined in displayed data coordinates.
+        """
+        return np.empty((0, 3))
 
     def _init_rotators(self):
         if len(self._initial_rotator_normals) == 0:
@@ -181,30 +203,30 @@ class BaseManipulator(ABC):
         self._rotator_normals = self._initial_rotator_normals.copy()
 
     @property
-    def visible(self) -> bool:
-        return self._visible
+    def layer(self):
+        return self._layer
 
-    @visible.setter
-    def visible(self, visible: bool):
-        # set visibility on visuals
-        self.node.visible = visible
-        if visible is True:
-            self.connect_callbacks()
-        else:
-            self.disconnect_callbacks()
-        self._visible = self.node.visible
+    @layer.setter
+    def layer(self, layer: Type[napari.layers.Layer]):
+        self._layer = layer
 
-    def connect_callbacks(self):
+    def set_layers(self, layer: Type[napari.layers.Layer]):
+        """Override this in a subclass with the correct layer type for the manipulator"""
+        self.layer = layer
+
+    def _on_enable(self):
+        self.node.visible = True
         add_mouse_callback_safe(
             self._layer.mouse_drag_callbacks,
-            self._on_click,
+            self._mouse_callback,
             index=0
         )
 
-    def disconnect_callbacks(self):
+    def _on_disable(self):
+        self.node.visible = False
         remove_mouse_callback_safe(
             self._layer.mouse_drag_callbacks,
-            self._on_click
+            self._mouse_callback
         )
 
     @property
@@ -263,7 +285,7 @@ class BaseManipulator(ABC):
 
     @property
     def translator_normals(self) -> np.ndarray:
-        return (self._initial_translator_normals @ self.rot_mat.T)
+        return (self._initial_translation_vectors @ self.rot_mat.T)
 
     @property
     def rotator_normals(self) -> np.ndarray:
@@ -311,7 +333,6 @@ class BaseManipulator(ABC):
             selected_translator_normal = None
         if (selected_rotator is not None) or (selected_translator is not None):
             layer.interactive = False
-
 
         initial_position_world = event.position
         yield
@@ -551,7 +572,6 @@ class BaseManipulator(ABC):
 
         self._on_matrix_change()
 
-
     def _on_data_change(self):
         """Change style of axes."""
 
@@ -594,7 +614,7 @@ class BaseManipulator(ABC):
 
     def _on_zoom_change(self):
         """Update axes length based on zoom scale."""
-        # if not self._viewer.axes.visible:
+        # if not self._viewer.axes.enabled:
         #     return
         return  # turn off temporarily
         scale = 1 / self._viewer.camera.zoom
@@ -608,7 +628,6 @@ class BaseManipulator(ABC):
         scale = target_canvas_pixels * scale_canvas2world
         # Update axes scale
         self.node.transform.scale = [scale, scale, scale, 1]
-
 
     def _on_matrix_change(self):
         # convert NumPy axis ordering to VisPy axis ordering

--- a/src/napari_threedee/manipulators/point_manipulator.py
+++ b/src/napari_threedee/manipulators/point_manipulator.py
@@ -32,7 +32,7 @@ class PointManipulator(BaseManipulator):
             order=order,
             translator_length=translator_length,
             rotator_radius=rotator_radius,
-            visible=False
+            enabled=False
         )
 
         self._on_selection_change()

--- a/src/napari_threedee/manipulators/qt_render_plane_manipulator.py
+++ b/src/napari_threedee/manipulators/qt_render_plane_manipulator.py
@@ -1,0 +1,9 @@
+import napari
+
+from .render_plane_manipulator import RenderPlaneManipulator
+from ..base import QtThreeDeeWidgetBase
+
+
+class QtRenderPlaneManipulatorWidget(QtThreeDeeWidgetBase):
+    def __init__(self,viewer: napari.Viewer, *args, **kwargs):
+        super().__init__(model=RenderPlaneManipulator, viewer=viewer, *args, **kwargs)

--- a/src/napari_threedee/manipulators/render_plane_manipulator.py
+++ b/src/napari_threedee/manipulators/render_plane_manipulator.py
@@ -10,14 +10,7 @@ class RenderPlaneManipulator(BaseManipulator):
     """A manipulator for moving an image layer rendering plane.
     """
 
-    def __init__(self, viewer, layer=None, order=0, translator_length=50, rotator_radius=5):
-
-        self._layer = layer
-        if self.layer is not None:
-            self._translation = np.array(self.layer.experimental_slicing_plane.position)
-        else:
-            self._translation = np.array([0, 0, 0])
-
+    def __init__(self, viewer, layer=None, order=0, translator_length=10, rotator_radius=5):
         super().__init__(
             viewer,
             layer,
@@ -28,6 +21,24 @@ class RenderPlaneManipulator(BaseManipulator):
 
     def set_layers(self, layer: napari.layers.Image):
         super().set_layers(layer)
+
+    def _initialize_transform(self):
+        if self.layer is not None:
+            self._translation = np.array(self.layer.experimental_slicing_plane.position)
+
+            # plane_normal =  np.array(self.layer.experimental_slicing_plane.normal)
+            # if np.allclose(plane_normal, [0, 1, 0]):
+            #     random_vec3 = np.array([1, 0, 0])
+            # else:
+            #     random_vec3 = np.array([0, 1, 0])
+            # vector_0 = plane_normal
+            # vector_1 = np.cross(vector_0, random_vec3)
+            # vector_2 = np.cross(vector_0, vector_1)
+            # self._rot_mat = np.column_stack([vector_0, vector_1, vector_2])
+            self._rot_mat = np.eye(3)
+        else:
+            self._translation = np.array([0, 0, 0])
+            self._rot_mat = np.eye(3)
 
     def _set_initial_translation_vectors(self):
         self._initial_translation_vectors = np.asarray(

--- a/src/napari_threedee/manipulators/render_plane_manipulator.py
+++ b/src/napari_threedee/manipulators/render_plane_manipulator.py
@@ -12,7 +12,7 @@ class RenderPlaneManipulator(BaseManipulator):
 
     def __init__(self, viewer, layer=None, order=0, translator_length=50, rotator_radius=5):
 
-        self.layer = layer
+        self._layer = layer
         if self.layer is not None:
             self._translation = np.array(self.layer.experimental_slicing_plane.position)
         else:
@@ -29,26 +29,18 @@ class RenderPlaneManipulator(BaseManipulator):
     def set_layers(self, layer: napari.layers.Image):
         super().set_layers(layer)
 
-    @cached_property
-    def _initial_translation_vectors(self):
-        if self.layer is not None:
-            return np.asarray([self.layer.experimental_slicing_plane.normal])
-        else:
-            return super()._initial_translation_vectors
+    def _set_initial_translation_vectors(self):
+        self._initial_translation_vectors = np.asarray(
+            [self.layer.experimental_slicing_plane.normal]
+        )
 
-    @cached_property
-    def _initial_rotator_normals(self):
-        # if self.layer is None:
-        #     return super()._initial_rotator_normals
-        normals = np.array(
-                [
-                    [1, 0, 0],
-                    [0, 0, 1],
-                    [0, 1, 0]
-                ]
-            )
-        normals[0] = self.layer.experimental_slicing_plane.normal
-        return normals
+    def _set_initial_rotator_normals(self):
+        normals = np.eye(3)
+        random_vec3 = np.array([0.7, 0.8, 0.9]) / np.linalg.norm([0.7, 0.8, 0.9])
+        normals[0] = np.array([self.layer.experimental_slicing_plane.normal])
+        normals[1] = np.cross(normals[0], random_vec3)
+        normals[2] = np.cross(normals[0], normals[1])
+        self._initial_rotator_normals = normals
 
     def _pre_drag(
             self,

--- a/src/napari_threedee/manipulators/render_plane_manipulator.py
+++ b/src/napari_threedee/manipulators/render_plane_manipulator.py
@@ -1,76 +1,22 @@
+from functools import cached_property
 from typing import Optional
 
+import napari.layers
 import numpy as np
-from napari.utils.geometry import project_points_onto_plane, rotation_matrix_from_vectors_3d
 from napari_threedee.manipulators.base_manipulator import BaseManipulator
 
 
 class RenderPlaneManipulator(BaseManipulator):
     """A manipulator for moving an image layer rendering plane.
-
-    Parameters
-    ----------
-    viewer : "napari.viewer.Viewer"
-        The napari viewer containing the visuals.
-    layer : Optional[napari.layers.base.Base]
-        The layer to attach the manipulator to.
-    order : int
-        The order to place the manipulator visuals in the vispy scene graph.
-    translator_length : float
-        The length of the translator arms in data units.
-    translator_width : float
-        The width of the translator arms in data units.
-    rotator_radius : float
-        The radius of the rotators in data units.
-    rotator_width : float
-        The width of the rotators in data units.
-
-    Attributes
-    ----------
-    centroid : np.ndarray
-        (3, 1) array containing the coordinates to the translation of the manipulator.
-    rot_mat : np.ndarray
-        (3, 3) array containing the rotation matrix applied to the manipluator.
-    translator_length : float
-        The length of the translator arms in data units.
-    translator_width : float
-        The width of the translator arms in data units.
-    rotator_radius : float
-        The radius of the rotators in data units.
-    rotator_width : float
-        The width of the rotators in data units.
-    translator_normals : np.ndarray
-        (N x 3) array containing the normal vector for each of the N translators.
-    rotator_normals : np.ndarray
-        (N x 3) array containing the normal vector for each of the N rotators.
-
-    Notes
-    -----
-    _N_SEGMENTS_ROTATOR : float
-        The number of segments to discretize the rotator into. More segments
-        makes the rotator look more smooth, but will reduce rendering performance.
-    _N_TUBE_POINTS : float
-        The number of points to use to represent the circular crossection of the
-        manipulator objects. More points makes the manipulator appear more smooth, but
-        will reduce the rendering performance.
     """
 
-    def __init__(self, viewer, layer, order=0, translator_length=50, rotator_radius=5):
+    def __init__(self, viewer, layer=None, order=0, translator_length=50, rotator_radius=5):
 
-        self._initial_plane_pos = None
-        self._rotator_angle_offset = 0
-        self._centroid = np.asarray(layer.experimental_slicing_plane.position)
-        normal = np.asarray(layer.experimental_slicing_plane.normal)
-        self._initial_translator_normals = np.asarray([normal])
-
-        self._initial_rotator_normals = np.array(
-            [
-                [1, 0, 0],
-                [0, 0, 1],
-                [0, 1, 0]
-            ]
-        )
-        self._initial_rotator_normals[0] = layer.experimental_slicing_plane.normal
+        self.layer = layer
+        if self.layer is not None:
+            self._translation = np.array(self.layer.experimental_slicing_plane.position)
+        else:
+            self._translation = np.array([0, 0, 0])
 
         super().__init__(
             viewer,
@@ -79,6 +25,30 @@ class RenderPlaneManipulator(BaseManipulator):
             translator_length=translator_length,
             rotator_radius=rotator_radius
         )
+
+    def set_layers(self, layer: napari.layers.Image):
+        super().set_layers(layer)
+
+    @cached_property
+    def _initial_translation_vectors(self):
+        if self.layer is not None:
+            return np.asarray([self.layer.experimental_slicing_plane.normal])
+        else:
+            return super()._initial_translation_vectors
+
+    @cached_property
+    def _initial_rotator_normals(self):
+        # if self.layer is None:
+        #     return super()._initial_rotator_normals
+        normals = np.array(
+                [
+                    [1, 0, 0],
+                    [0, 0, 1],
+                    [0, 1, 0]
+                ]
+            )
+        normals[0] = self.layer.experimental_slicing_plane.normal
+        return normals
 
     def _pre_drag(
             self,

--- a/src/napari_threedee/manipulators/render_plane_manipulator.py
+++ b/src/napari_threedee/manipulators/render_plane_manipulator.py
@@ -36,7 +36,7 @@ class RenderPlaneManipulator(BaseManipulator):
 
     def _set_initial_rotator_normals(self):
         normals = np.eye(3)
-        random_vec3 = np.array([0.7, 0.8, 0.9]) / np.linalg.norm([0.7, 0.8, 0.9])
+        random_vec3 = np.array([0, 1, 0]) / np.linalg.norm([0, 1, 0])
         normals[0] = np.array([self.layer.experimental_slicing_plane.normal])
         normals[1] = np.cross(normals[0], random_vec3)
         normals[2] = np.cross(normals[0], normals[1])


### PR DESCRIPTION
Sorry for the large PR, this includes

- a base model `ThreeDeeModel` for all manipulator/annotator objects in napari-threedee
- a widget which can autogenerate GUI elements from a given `ThreeDeeModel` class
- example implementation of a `PlanePointAnnotator` using this API
- refactor `BaseManipulator` to follow this API
- set initial rotator normals for all rotators in `RenderingPlaneManipulator`

Refactoring the `BaseManipulator` mainly involved making it so we can switch layers in and out. Autogeneration of GUIs doesn't work for manipulators yet because our manipulators don't gracefully handle the `layer=None` case

There is also a bug which appears if the initial rotators don't align with the initial rotation matrix (`np.eye(3)`) - I've changed the render plane example to highlight this, video here

https://user-images.githubusercontent.com/7307488/155028179-dbc3882d-0892-44aa-b47e-dd880937de52.mp4

Sorry I couldn't push this all the way but I think things are in a nice enough state now to keep pushing - nothing that wasn't already broken before is broken now and we're much closer to a consistent API and autogenerated GUIs for everything :)

Would love to hear any thoughts you have whilst looking this over, cheers dude!

